### PR TITLE
Added command line utils for style check and and reformatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := help
+
+.PHONY: install
+install: # Install spond from local using pip, including dependencies
+	pip install -e .
+
+.PHONY: lint
+lint: ## Run black formatter and isort your imports with isort
+	black --quiet -l 120 spond tests examples
+	isort .
+
+.PHONY: flake8
+flake8: # Check coding style according to pycodestyle (PEP8) and pydocstyle (PEP257). Ignore unused imports.
+	flake8 --show-source --max-line-length=120 --ignore=F401
+
+# ref: https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+help: ## Generate this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-45s\033[0m %s\n", $$1, $$2}'	

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ There is not yet a stable version (nor an official release of this library). All
 
 To install the latest development version, clone from GitHub and instal the local repo using pip.
 1. Use `git` to clone the latest version to your local machine: `git clone https://github.com/roads/spond.git`
-2. Use `pip` to install the cloned repo (using editable mode): `pip install -e /local/path/to/spond`
-By using editable mode, you can easily update your local copy by use `git pull origin master` inside your local copy of the repo. You do not have to re-install with `pip`.
+2. Use `make install` to install the cloned repo which executes `pip install -e` in editable mode. By using editable mode, you can easily update your local copy by use `git pull origin master` inside your local copy of the repo. You do not have to re-install with `pip`.
 
 The package can also be obtained by:
 * Manually downloading the latest version at https://github.com/roads/spond.git
@@ -25,6 +24,20 @@ TODO
 
 ## Modules
 TODO
+
+## Style Checks and Formatting
+To check if your code complies with `pycodestyle` (PEP 8) and `pydocstyle` (PEP 257), use
+```bash
+make flake8
+```
+To automatically reformat your code for `pycodestyle` and sort import stastements, use
+```bash
+make lint
+```
+which runs `black` for formatting and `isort` for sorting. Make sure that the dependent libraries are installed by running
+```bash
+make install
+```
 
 ## Contributers
 PI:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     packages=['spond'],
     python_requires='>=3.8, <3.9',
     install_requires=[
-        'torch', 'torchvision', 'numpy', 'scipy', 'scikit-learn', 'tinydb'
+        'torch', 'torchvision', 'numpy', 'scipy', 'scikit-learn', 'tinydb', 'flake8', 'flake8-docstrings', 'black', 'isort'
     ],
     include_package_data=True,
     url='https://github.com/roads/spond',


### PR DESCRIPTION
### Overview
Added a `Makefile` in the root directory to enable commands for installation, style checking for `pycodestyle` (formerly known as PEP8) and `pydocstyle` (formerly known as PEP 257). We currently ignore the unused imported package error, but this is subject to change along with other errors. The list of errors can be found in  https://flake8.pycqa.org/en/3.1.1/user/error-codes.html

### Examples
Now the local install of `spond` can be done via the following command.
```bash
make install
```
Following the install, you can check if your python code complies with `pycodestyle` and `pydocstyle` by running
```bash
make flake8
```
Some issues can be automatically fixed with `black` and `isort`, which can be executed via
```bash
make lint
```
### Related Issues
See: Commit style checks. #9